### PR TITLE
Add animations, rich blog system, and visual design uplift

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -9,25 +9,45 @@ import {
   faLinkedin,
   faXTwitter,
 } from "@fortawesome/free-brands-svg-icons";
-import { faEnvelope } from "@fortawesome/free-solid-svg-icons";
+import { faDownload, faEnvelope } from "@fortawesome/free-solid-svg-icons";
 
 import profilePic from "@/assets/FB_Profile.jpg";
+import { FadeIn, StaggerChildren } from "@/components/motion";
 
 function SocialLink({
   className,
   href,
   children,
   icon: Icon,
+  download,
 }: {
   className?: string;
   href: string;
   icon: any;
   children: React.ReactNode;
+  download?: string;
 }) {
+  const linkClasses =
+    "group flex text-sm font-medium text-zinc-800 transition hover:text-primary-500 dark:text-zinc-200 dark:hover:text-primary-500";
+
+  if (download) {
+    return (
+      <li className={clsx(className, "flex")}>
+        <a className={linkClasses} download={download} href={href}>
+          <FontAwesomeIcon
+            className="h-6 w-6 flex-none fill-zinc-500 transition group-hover:fill-primary-500"
+            icon={Icon}
+          />
+          <span className="ml-4">{children}</span>
+        </a>
+      </li>
+    );
+  }
+
   return (
     <li className={clsx(className, "flex")}>
       <Link
-        className="group flex text-sm font-medium text-zinc-800 transition hover:text-primary-500 dark:text-zinc-200 dark:hover:text-primary-500"
+        className={linkClasses}
         href={href}
         rel="noopener noreferrer"
         target="_blank"
@@ -45,14 +65,14 @@ function SocialLink({
 export const metadata: Metadata = {
   title: "About",
   description:
-    "I’m Ryan Milton. I live in the Emerald City, where I design the future.",
+    "I'm Ryan Milton. I live in the Emerald City, where I design the future.",
 };
 
 export default function About() {
   return (
     <div className="mt-16">
       <div className="grid grid-cols-1 gap-y-16 lg:grid-cols-2 lg:grid-rows-[auto_1fr] lg:gap-y-12">
-        <div className="lg:pl-20">
+        <FadeIn className="lg:pl-20" direction="right">
           <div className="max-w-xs px-2.5 lg:max-w-none">
             <Image
               alt=""
@@ -61,84 +81,122 @@ export default function About() {
               src={profilePic}
             />
           </div>
-        </div>
+        </FadeIn>
         <div className="lg:order-first lg:row-span-2">
-          <h1 className="text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100">
-            I’m Ryan Milton. I live in Seattle, where I develop for the future.
-          </h1>
-          <div className="mt-6 space-y-7 text-base text-zinc-600 dark:text-zinc-400">
-            <p>
-              I’ve loved technology for as long as I can remember. When I was
-              young my dad worked as a hardware engineer and would bring home
-              old computers for me to take apart and put back together. I’d
-              spend hours in our garage, surrounded by the smell of solder and
-              the hum of the air conditioner, trying to figure out how
-              everything fit together, tweaking and reinstalling the BIOS. I was
-              hooked.
-            </p>
-            <p>
-              After I graduated high school, I joined the Navy as an Aviation
-              Electrian and worked on EA-18G Growlers and F/A-18 Super Hornets.
-              I was spent alot of time on many different aircraft carriers, on
-              the flight deck, in the Persian Gulf, and in Afghanistan. I loved
-              the smell of jet fuel and the sound of the engines, but I knew I
-              wanted to do more.
-            </p>
-            <p>
-              During my last 2 years in the Navy I started learning how to code.
-              I started with the basics; HTML, CSS, and JavaScript. After I got
-              out, I went to a coding bootcamp in Seattle and learned how to
-              build full stack applications. I loved the challenge of learning
-              new things and building something from nothing. I knew I had found
-              my calling.
-            </p>
-            <p>
-              Today, I work as a software engineer, focusing on creating
-              beautiful and intuituve user interfaces using the latest
-              technologies. I love what I do and I’m always looking for ways to
-              improve my skills and learn new things. I’m excited to see what
-              the future holds.
-            </p>
-            <p>
-              Oh, and I have a healthy obsession with japanese Kei cars and
-              trucks. Check the Insta lol.
-            </p>
-          </div>
+          <FadeIn>
+            <h1 className="text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100">
+              I&apos;m Ryan Milton. I live in Seattle, where I develop for the
+              future.
+            </h1>
+          </FadeIn>
+          <StaggerChildren
+            className="mt-6 space-y-7 text-base text-zinc-600 dark:text-zinc-400"
+            staggerDelay={0.08}
+          >
+            <FadeIn>
+              <p>
+                I&apos;ve loved technology for as long as I can remember. When I
+                was young my dad worked as a hardware engineer and would bring
+                home old computers for me to take apart and put back together.
+                I&apos;d spend hours in our garage, surrounded by the smell of
+                solder and the hum of the air conditioner, trying to figure out
+                how everything fit together, tweaking and reinstalling the BIOS.
+                I was hooked.
+              </p>
+            </FadeIn>
+            <FadeIn>
+              <p>
+                After I graduated high school, I joined the Navy as an Aviation
+                Electrian and worked on EA-18G Growlers and F/A-18 Super
+                Hornets. I spent a lot of time on many different aircraft
+                carriers, on the flight deck, in the Persian Gulf, and in
+                Afghanistan. I loved the smell of jet fuel and the sound of the
+                engines, but I knew I wanted to do more.
+              </p>
+            </FadeIn>
+            <FadeIn>
+              <p>
+                During my last 2 years in the Navy I started learning how to
+                code. I started with the basics; HTML, CSS, and JavaScript.
+                After I got out, I went to a coding bootcamp in Seattle and
+                learned how to build full stack applications. I loved the
+                challenge of learning new things and building something from
+                nothing. I knew I had found my calling.
+              </p>
+            </FadeIn>
+            <FadeIn>
+              <p>
+                Today, I work as a software engineer, focusing on creating
+                beautiful and intuitive user interfaces using the latest
+                technologies. I love what I do and I&apos;m always looking for
+                ways to improve my skills and learn new things. I&apos;m excited
+                to see what the future holds.
+              </p>
+            </FadeIn>
+            <FadeIn>
+              <p>
+                Oh, and I have a healthy obsession with japanese Kei cars and
+                trucks. Check the Insta lol.
+              </p>
+            </FadeIn>
+          </StaggerChildren>
         </div>
         <div className="lg:pl-20">
-          <ul>
-            <SocialLink href="https://x.com/ryan__milton" icon={faXTwitter}>
-              Follow on X
-            </SocialLink>
-            <SocialLink
-              className="mt-4"
-              href="https://www.instagram.com/ryan_ohkeilife"
-              icon={faInstagram}
-            >
-              Follow on Instagram
-            </SocialLink>
-            <SocialLink
-              className="mt-4"
-              href="https://github.com/Ryan-Milton"
-              icon={faGithub}
-            >
-              Follow on GitHub
-            </SocialLink>
-            <SocialLink
-              className="mt-4"
-              href="https://www.linkedin.com/in/ryanmilton"
-              icon={faLinkedin}
-            >
-              Follow on LinkedIn
-            </SocialLink>
-            <SocialLink
-              className="mt-8 border-t border-zinc-100 pt-8 dark:border-zinc-700/40"
-              href="mailto:mr.ryan.milton@gmail.com?subject=Inquiry%20About%20Your%20Services"
-              icon={faEnvelope}
-            >
-              mr.ryan.milton@gmail.com
-            </SocialLink>
-          </ul>
+          <StaggerChildren staggerDelay={0.06}>
+            <ul>
+              <FadeIn>
+                <SocialLink href="https://x.com/ryan__milton" icon={faXTwitter}>
+                  Follow on X
+                </SocialLink>
+              </FadeIn>
+              <FadeIn>
+                <SocialLink
+                  className="mt-4"
+                  href="https://www.instagram.com/ryan_ohkeilife"
+                  icon={faInstagram}
+                >
+                  Follow on Instagram
+                </SocialLink>
+              </FadeIn>
+              <FadeIn>
+                <SocialLink
+                  className="mt-4"
+                  href="https://github.com/Ryan-Milton"
+                  icon={faGithub}
+                >
+                  Follow on GitHub
+                </SocialLink>
+              </FadeIn>
+              <FadeIn>
+                <SocialLink
+                  className="mt-4"
+                  href="https://www.linkedin.com/in/ryanmilton"
+                  icon={faLinkedin}
+                >
+                  Follow on LinkedIn
+                </SocialLink>
+              </FadeIn>
+              <FadeIn>
+                <SocialLink
+                  className="mt-4"
+                  download="Ryan_Milton_Resume.pdf"
+                  href="/resume.pdf"
+                  icon={faDownload}
+                >
+                  Download Resume
+                </SocialLink>
+              </FadeIn>
+              <FadeIn>
+                <SocialLink
+                  className="mt-8 border-t border-zinc-100 pt-8 dark:border-zinc-700/40"
+                  href="mailto:mr.ryan.milton@gmail.com?subject=Inquiry%20About%20Your%20Services"
+                  icon={faEnvelope}
+                >
+                  mr.ryan.milton@gmail.com
+                </SocialLink>
+              </FadeIn>
+            </ul>
+          </StaggerChildren>
         </div>
       </div>
     </div>

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,8 +1,13 @@
 import { Metadata } from "next";
+import Image from "next/image";
 import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
 
-import { getPostBySlug, getAllSlugs } from "@/lib/blog";
+import { getPostBySlug, getAllSlugs, getReadingTime } from "@/lib/blog";
+import { mdxOptions } from "@/lib/mdx-options";
+import { mdxComponents } from "@/components/mdx";
+import { extractToc } from "@/lib/toc";
+import { TableOfContents } from "@/components/mdx/table-of-contents";
 
 interface BlogPostProps {
   params: { slug: string };
@@ -28,19 +33,39 @@ export default function BlogPost({ params }: BlogPostProps) {
 
   if (!post) notFound();
 
+  const readingTimeMinutes = getReadingTime(post.content);
+  const toc = extractToc(post.content);
+
   return (
     <article className="container mx-auto max-w-3xl py-8">
       <header className="mb-8">
+        {post.image && (
+          <div className="mb-6 overflow-hidden rounded-xl">
+            <Image
+              priority
+              alt={post.title}
+              className="w-full"
+              height={630}
+              sizes="(max-width: 768px) 100vw, 720px"
+              src={post.image}
+              width={1200}
+            />
+          </div>
+        )}
         <h1 className="text-3xl font-bold tracking-tight text-zinc-800 sm:text-4xl dark:text-zinc-100">
           {post.title}
         </h1>
-        <p className="mt-2 text-sm text-zinc-500 dark:text-zinc-400">
-          {new Date(post.publishedAt).toLocaleDateString("en-US", {
-            year: "numeric",
-            month: "long",
-            day: "numeric",
-          })}
-        </p>
+        <div className="mt-2 flex items-center gap-3 text-sm text-zinc-500 dark:text-zinc-400">
+          <time dateTime={post.publishedAt}>
+            {new Date(post.publishedAt).toLocaleDateString("en-US", {
+              year: "numeric",
+              month: "long",
+              day: "numeric",
+            })}
+          </time>
+          <span aria-hidden="true">&middot;</span>
+          <span>{readingTimeMinutes} min read</span>
+        </div>
         {post.tags && post.tags.length > 0 && (
           <div className="mt-3 flex gap-2">
             {post.tags.map((tag) => (
@@ -54,8 +79,13 @@ export default function BlogPost({ params }: BlogPostProps) {
           </div>
         )}
       </header>
-      <div className="prose prose-zinc dark:prose-invert max-w-none">
-        <MDXRemote source={post.content} />
+      <TableOfContents items={toc} />
+      <div className="prose prose-zinc max-w-none dark:prose-invert">
+        <MDXRemote
+          components={mdxComponents}
+          options={{ mdxOptions: mdxOptions as any }}
+          source={post.content}
+        />
       </div>
     </article>
   );

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -39,7 +39,7 @@ export default function BlogPost({ params }: BlogPostProps) {
   return (
     <article className="container mx-auto max-w-3xl py-8">
       <header className="mb-8">
-        {post.image && (
+        {post.image && !post.image.startsWith("http") && (
           <div className="mb-6 overflow-hidden rounded-xl">
             <Image
               priority
@@ -49,6 +49,16 @@ export default function BlogPost({ params }: BlogPostProps) {
               sizes="(max-width: 768px) 100vw, 720px"
               src={post.image}
               width={1200}
+            />
+          </div>
+        )}
+        {post.image && post.image.startsWith("http") && (
+          <div className="mb-6 overflow-hidden rounded-xl">
+            {/* eslint-disable-next-line */}
+            <img
+              alt={post.title}
+              className="w-full rounded-xl"
+              src={post.image}
             />
           </div>
         )}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -33,8 +33,8 @@ export default function BlogPage() {
       <div className="mb-12 h-px w-full bg-gradient-to-r from-transparent via-zinc-300 to-transparent dark:via-zinc-700" />
 
       <AnimatedGrid className="flex flex-col gap-6">
-        {posts.map((post, i) => (
-          <AnimatedGridItem key={post.slug} index={i}>
+        {posts.map((post) => (
+          <AnimatedGridItem key={post.slug}>
             <PostCard post={post} />
           </AnimatedGridItem>
         ))}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -2,6 +2,8 @@ import { Metadata } from "next";
 
 import { getAllPosts } from "@/lib/blog";
 import PostCard from "@/components/blogPostCard";
+import { AnimatedGrid, AnimatedGridItem } from "@/components/animatedGrid";
+import { FadeIn } from "@/components/motion";
 
 export const metadata: Metadata = {
   title: "Blog",
@@ -14,32 +16,29 @@ export default function BlogPage() {
 
   return (
     <div>
-      <div className="max-w-2xl">
-        <h1 className="text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100">
-          Writing on software design, company building, and any other topic I
-          find interesting.
-        </h1>
-        <p className="text-zinc-600 dark:text-zinc-400 mt-6 mb-16">
-          A collection of thoughts many deem came from a genius... or was it a
-          madman?
-        </p>
-      </div>
-      <div className="md:border-l md:border-zinc-100 md:pl-6 md:dark:border-zinc-700/40">
-        <div className="flex flex-col gap-8">
-          {posts.map((post) => (
-            <div key={post.slug} className="flex flex-row">
-              <p className="text-sm text-zinc-400 dark:text-zinc-500 w-1/5 hidden md:block">
-                {new Date(post.publishedAt).toLocaleDateString("en-US", {
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                })}
-              </p>
-              <PostCard post={post} />
-            </div>
-          ))}
+      <FadeIn>
+        <div className="max-w-2xl">
+          <h1 className="text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100">
+            Writing on software design, company building, and any other topic I
+            find interesting.
+          </h1>
+          <p className="mt-6 mb-12 text-zinc-600 dark:text-zinc-400">
+            A collection of thoughts many deem came from a genius... or was it a
+            madman?
+          </p>
         </div>
-      </div>
+      </FadeIn>
+
+      {/* Gradient divider */}
+      <div className="mb-12 h-px w-full bg-gradient-to-r from-transparent via-zinc-300 to-transparent dark:via-zinc-700" />
+
+      <AnimatedGrid className="flex flex-col gap-6">
+        {posts.map((post, i) => (
+          <AnimatedGridItem key={post.slug} index={i}>
+            <PostCard post={post} />
+          </AnimatedGridItem>
+        ))}
+      </AnimatedGrid>
     </div>
   );
 }

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect } from "react";
+import { motion } from "framer-motion";
+import { Button } from "@nextui-org/react";
 
 export default function Error({
   error,
@@ -10,22 +12,54 @@ export default function Error({
   reset: () => void;
 }) {
   useEffect(() => {
-    // Log the error to an error reporting service
     /* eslint-disable no-console */
     console.error(error);
   }, [error]);
 
   return (
-    <div>
-      <h2>Something went wrong!</h2>
-      <button
-        onClick={
-          // Attempt to recover by trying to re-render the segment
-          () => reset()
-        }
+    <div className="flex min-h-[60vh] flex-col items-center justify-center px-6 text-center">
+      <motion.div
+        animate={{ opacity: 1, y: 0 }}
+        initial={{ opacity: 0, y: 20 }}
+        transition={{ duration: 0.5 }}
       >
-        Try again
-      </button>
+        <span className="text-8xl font-bold text-zinc-200 dark:text-zinc-800">
+          :(
+        </span>
+      </motion.div>
+
+      <motion.h2
+        animate={{ opacity: 1, y: 0 }}
+        className="mt-6 text-2xl font-bold tracking-tight text-zinc-800 dark:text-zinc-100"
+        initial={{ opacity: 0, y: 20 }}
+        transition={{ delay: 0.1, duration: 0.5 }}
+      >
+        Something went wrong
+      </motion.h2>
+
+      <motion.p
+        animate={{ opacity: 1, y: 0 }}
+        className="mt-3 max-w-md text-base text-zinc-600 dark:text-zinc-400"
+        initial={{ opacity: 0, y: 20 }}
+        transition={{ delay: 0.2, duration: 0.5 }}
+      >
+        An unexpected error occurred. You can try again or head back to the
+        homepage.
+      </motion.p>
+
+      <motion.div
+        animate={{ opacity: 1, y: 0 }}
+        className="mt-8 flex gap-4"
+        initial={{ opacity: 0, y: 20 }}
+        transition={{ delay: 0.3, duration: 0.5 }}
+      >
+        <Button color="primary" onPress={() => reset()}>
+          Try again
+        </Button>
+        <Button as="a" href="/" variant="bordered">
+          Go home
+        </Button>
+      </motion.div>
     </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,15 +1,22 @@
+import "@fortawesome/fontawesome-svg-core/styles.css";
 import "@/styles/globals.css";
+
+import { config } from "@fortawesome/fontawesome-svg-core";
 import { Metadata, Viewport } from "next";
 import clsx from "clsx";
-import { Popover, PopoverTrigger, PopoverContent } from "@nextui-org/react";
 
 import { Providers } from "./providers";
 
 import { siteConfig } from "@/config/site";
 import { fontSans } from "@/config/fonts";
 import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+import { PageTransition } from "@/components/motion";
+
+config.autoAddCss = false;
 
 export const metadata: Metadata = {
+  metadataBase: new URL(siteConfig.url),
   title: {
     default: siteConfig.name,
     template: `%s - ${siteConfig.name}`,
@@ -17,6 +24,20 @@ export const metadata: Metadata = {
   description: siteConfig.description,
   icons: {
     icon: "/favicon.ico",
+  },
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: siteConfig.url,
+    siteName: siteConfig.name,
+    title: siteConfig.name,
+    description: siteConfig.description,
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: siteConfig.name,
+    description: siteConfig.description,
+    creator: "@ryan__milton",
   },
 };
 
@@ -42,33 +63,14 @@ export default function RootLayout({
         )}
       >
         <Providers themeProps={{ attribute: "class", defaultTheme: "dark" }}>
-          <div className="relative flex flex-col h-screen">
-            <main className="container mx-auto max-w-7xl flex-grow bg-zinc-100 dark:bg-zinc-950">
+          <div className="relative flex flex-col min-h-screen">
+            <main className="container mx-auto max-w-7xl flex-grow bg-zinc-50 bg-atmosphere dark:bg-zinc-950">
               <Navbar />
-              <div className="px-6">{children}</div>
-              <footer className="w-full flex items-center justify-center py-3">
-                <div className="flex items-center gap-1 text-current">
-                  <span className="text-default-600">Powered by</span>
-                  <Popover placement="top" showArrow={true}>
-                    <PopoverTrigger>
-                      <span className="text-amber-900 cursor-pointer">
-                        Coffee
-                      </span>
-                    </PopoverTrigger>
-                    <PopoverContent>
-                      <div className="px-1 py-2 max-w-40">
-                        <div className="text-xs font-semibold">
-                          A delicious hot beverage.
-                        </div>
-                        <div className="text-xs">
-                          Hazlenut - add a splash of cream 🤌🏻
-                        </div>
-                      </div>
-                    </PopoverContent>
-                  </Popover>
-                </div>
-              </footer>
+              <div className="px-6">
+                <PageTransition>{children}</PageTransition>
+              </div>
             </main>
+            <Footer />
           </div>
         </Providers>
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,8 @@ import { getAllPosts } from "@/lib/blog";
 import PostCard from "@/components/blogPostCard";
 import Resume from "@/components/resume";
 import SocialLink from "@/components/socialLink";
+import { FadeIn, StaggerChildren } from "@/components/motion";
+import { title } from "@/components/primitives";
 
 export default function Home() {
   const posts = getAllPosts();
@@ -18,93 +20,145 @@ export default function Home() {
 
   return (
     <section className="flex flex-col items-center justify-center gap-4 pb-8 md:py-10">
-      <div className="inline-block max-w-5xl text-center justify-center">
+      <div className="inline-block max-w-5xl justify-center text-center">
         {/* Hero */}
-        <div className="mt-9">
+        <div className="mt-16 md:mt-24">
           <div className="max-w-2xl text-left">
-            <h1 className="text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100">
-              Software designer, creator, and kei car enthusiast.
-            </h1>
-            <p className="mt-6 text-base text-zinc-600 dark:text-zinc-400">
-              I&apos;m Ryan, a software designer and entrepreneur based in
-              Seattle, WA. I&apos;m the co-founder and CTO of EVA, where we are
-              revolutionizing digital assistants through the power of
-              multi-modal LLM&apos;s. I&apos;m also the co-founder of OhKei
-              Life, a lifestyle brand that focuses on the kei car community.
-            </p>
-            <div className="mt-6 flex gap-2">
-              <SocialLink href="https://x.com/ryan__milton" icon={faXTwitter} />
-              <SocialLink
-                href="https://www.instagram.com/ryan_ohkeilife"
-                icon={faInstagram}
-              />
-              <SocialLink
-                href="https://github.com/Ryan-Milton"
-                icon={faGithub}
-              />
-              <SocialLink
-                href="https://www.linkedin.com/in/ryanmilton"
-                icon={faLinkedin}
-              />
-            </div>
+            <FadeIn delay={0}>
+              <p className="text-sm font-medium uppercase tracking-widest text-zinc-500 dark:text-zinc-400">
+                Ryan Milton
+              </p>
+            </FadeIn>
+            <FadeIn delay={0.1}>
+              <h1 className="mt-3 text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100">
+                Software designer, creator, and{" "}
+                <span className={title({ color: "violet", size: "sm" })}>
+                  kei car enthusiast
+                </span>
+                .
+              </h1>
+            </FadeIn>
+            <FadeIn delay={0.2}>
+              <p className="mt-6 max-w-2xl text-base text-zinc-600 dark:text-zinc-400">
+                I&apos;m Ryan, a software designer and entrepreneur based in
+                Seattle, WA. I&apos;m the co-founder and CTO of EVA, where we
+                are revolutionizing digital assistants through the power of
+                multi-modal LLM&apos;s. I&apos;m also the co-founder of OhKei
+                Life, a lifestyle brand that focuses on the kei car community.
+              </p>
+            </FadeIn>
+            <StaggerChildren className="mt-6 flex gap-2" staggerDelay={0.08}>
+              <FadeIn>
+                <SocialLink
+                  href="https://x.com/ryan__milton"
+                  icon={faXTwitter}
+                />
+              </FadeIn>
+              <FadeIn>
+                <SocialLink
+                  href="https://www.instagram.com/ryan_ohkeilife"
+                  icon={faInstagram}
+                />
+              </FadeIn>
+              <FadeIn>
+                <SocialLink
+                  href="https://github.com/Ryan-Milton"
+                  icon={faGithub}
+                />
+              </FadeIn>
+              <FadeIn>
+                <SocialLink
+                  href="https://www.linkedin.com/in/ryanmilton"
+                  icon={faLinkedin}
+                />
+              </FadeIn>
+            </StaggerChildren>
           </div>
         </div>
 
+        {/* Gradient divider */}
+        <div className="mt-16 h-px w-full bg-gradient-to-r from-transparent via-zinc-300 to-transparent dark:via-zinc-700" />
+
         {/* Featured Posts + Resume */}
-        <div className="mt-24 md:mt-28">
+        <div className="mt-16 md:mt-20">
           <div className="mx-auto grid max-w-xl grid-cols-1 gap-y-20 lg:max-w-none lg:grid-cols-2">
             <div className="flex flex-col gap-8">
-              {featuredPosts.map((post) => (
-                <PostCard key={post.slug} post={post} />
+              {featuredPosts.map((post, i) => (
+                <FadeIn key={post.slug} delay={i * 0.1}>
+                  <PostCard post={post} />
+                </FadeIn>
               ))}
               {posts.length > 3 && (
-                <Link
-                  className="text-sm font-medium text-primary-500 dark:text-primary-400"
-                  href="/blog"
-                >
-                  Read more posts →
-                </Link>
+                <FadeIn delay={0.3}>
+                  <Link
+                    className="group text-sm font-medium text-primary-500 dark:text-primary-400"
+                    href="/blog"
+                  >
+                    Read more posts{" "}
+                    <span className="inline-block transition-transform duration-200 group-hover:translate-x-1">
+                      &rarr;
+                    </span>
+                  </Link>
+                </FadeIn>
               )}
             </div>
-            <div className="space-y-10 lg:pl-16 xl:pl-24">
-              <Resume />
-            </div>
+            <FadeIn delay={0.2} direction="right">
+              <div className="space-y-10 lg:pl-16 xl:pl-24">
+                <Resume />
+              </div>
+            </FadeIn>
           </div>
         </div>
 
         {/* Contact Section */}
-        <div className="mt-24 md:mt-28 border-t border-zinc-100 dark:border-zinc-700/40 pt-12">
-          <div className="max-w-2xl text-left">
-            <h2 className="text-2xl font-bold tracking-tight text-zinc-800 sm:text-3xl dark:text-zinc-100">
-              Get in Touch
-            </h2>
-            <p className="mt-4 text-base text-zinc-600 dark:text-zinc-400">
-              I&apos;m always open to new opportunities, collaborations, or just
-              a good conversation. Feel free to reach out through any of the
-              channels below.
-            </p>
-            <ul className="mt-6 space-y-4">
-              <SocialLink
-                href="mailto:mr.ryan.milton@gmail.com?subject=Inquiry%20About%20Your%20Services"
-                icon={faEnvelope}
-              >
-                mr.ryan.milton@gmail.com
-              </SocialLink>
-              <SocialLink href="https://x.com/ryan__milton" icon={faXTwitter}>
-                Follow on X
-              </SocialLink>
-              <SocialLink href="https://github.com/Ryan-Milton" icon={faGithub}>
-                Follow on GitHub
-              </SocialLink>
-              <SocialLink
-                href="https://www.linkedin.com/in/ryanmilton"
-                icon={faLinkedin}
-              >
-                Connect on LinkedIn
-              </SocialLink>
-            </ul>
+        <FadeIn>
+          <div className="mt-24 border-t border-zinc-100 pt-12 md:mt-28 dark:border-zinc-700/40">
+            <div className="max-w-2xl text-left">
+              <h2 className="text-2xl font-bold tracking-tight text-zinc-800 sm:text-3xl dark:text-zinc-100">
+                Get in Touch
+              </h2>
+              <p className="mt-4 text-base text-zinc-600 dark:text-zinc-400">
+                I&apos;m always open to new opportunities, collaborations, or
+                just a good conversation. Feel free to reach out through any of
+                the channels below.
+              </p>
+              <StaggerChildren className="mt-6 space-y-4" staggerDelay={0.08}>
+                <FadeIn>
+                  <SocialLink
+                    href="mailto:mr.ryan.milton@gmail.com?subject=Inquiry%20About%20Your%20Services"
+                    icon={faEnvelope}
+                  >
+                    mr.ryan.milton@gmail.com
+                  </SocialLink>
+                </FadeIn>
+                <FadeIn>
+                  <SocialLink
+                    href="https://x.com/ryan__milton"
+                    icon={faXTwitter}
+                  >
+                    Follow on X
+                  </SocialLink>
+                </FadeIn>
+                <FadeIn>
+                  <SocialLink
+                    href="https://github.com/Ryan-Milton"
+                    icon={faGithub}
+                  >
+                    Follow on GitHub
+                  </SocialLink>
+                </FadeIn>
+                <FadeIn>
+                  <SocialLink
+                    href="https://www.linkedin.com/in/ryanmilton"
+                    icon={faLinkedin}
+                  >
+                    Connect on LinkedIn
+                  </SocialLink>
+                </FadeIn>
+              </StaggerChildren>
+            </div>
           </div>
-        </div>
+        </FadeIn>
       </div>
     </section>
   );

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,7 +1,10 @@
 import { Metadata } from "next";
 
 import { projects } from "@/config/projects";
+import { accentClasses } from "@/config/colors";
 import ProjectCard from "@/components/projectCard";
+import { AnimatedGrid, AnimatedGridItem } from "@/components/animatedGrid";
+import { FadeIn } from "@/components/motion";
 
 export const metadata: Metadata = {
   title: "Projects",
@@ -9,23 +12,71 @@ export const metadata: Metadata = {
 };
 
 export default function ProjectsPage() {
+  const featured = projects.find((p) => p.featured);
+  const remaining = projects.filter((p) => !p.featured);
+
   return (
     <div>
-      <div className="max-w-2xl">
-        <h1 className="text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100">
-          Things I&apos;ve built and worked on.
-        </h1>
-        <p className="mt-6 text-base text-zinc-600 dark:text-zinc-400">
-          A collection of projects that I&apos;ve poured my time and energy
-          into. From AI-powered assistants to lifestyle brands, these are the
-          things that keep me up at night (in a good way).
-        </p>
-      </div>
-      <div className="mt-16 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {projects.map((project) => (
-          <ProjectCard key={project.name} project={project} />
+      <FadeIn>
+        <div className="max-w-2xl">
+          <h1 className="text-4xl font-bold tracking-tight text-zinc-800 sm:text-5xl dark:text-zinc-100">
+            Things I&apos;ve built and worked on.
+          </h1>
+          <p className="mt-6 text-base text-zinc-600 dark:text-zinc-400">
+            A collection of projects that I&apos;ve poured my time and energy
+            into. From AI-powered assistants to lifestyle brands, these are the
+            things that keep me up at night (in a good way).
+          </p>
+        </div>
+      </FadeIn>
+
+      {/* Featured project */}
+      {featured && (
+        <FadeIn className="mt-12" delay={0.1}>
+          <div
+            className={`relative overflow-hidden rounded-xl border border-zinc-100 bg-zinc-50/10 p-6 md:p-8 dark:border-zinc-700/40 dark:bg-zinc-800/10`}
+          >
+            <div
+              className={`absolute inset-y-0 left-0 w-1 bg-gradient-to-b ${accentClasses[featured.accent || "blue"].border}`}
+            />
+            <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+              <div className="flex-1">
+                <span className="text-xs font-medium uppercase tracking-wider text-zinc-400 dark:text-zinc-500">
+                  Featured Project
+                </span>
+                <h2 className="mt-2 text-2xl font-bold text-zinc-900 dark:text-zinc-100">
+                  {featured.name}
+                </h2>
+                <p className="mt-3 text-base text-zinc-600 dark:text-zinc-400">
+                  {featured.description}
+                </p>
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {featured.techStack.map((tech) => (
+                    <span
+                      key={tech}
+                      className={`rounded-full px-3 py-1 text-xs font-medium ${accentClasses[featured.accent || "blue"].badge}`}
+                    >
+                      {tech}
+                    </span>
+                  ))}
+                </div>
+              </div>
+              <div
+                className={`hidden h-32 w-32 rounded-full bg-gradient-to-br opacity-20 blur-2xl md:block ${accentClasses[featured.accent || "blue"].border}`}
+              />
+            </div>
+          </div>
+        </FadeIn>
+      )}
+
+      {/* Project grid */}
+      <AnimatedGrid className="mt-12 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        {remaining.map((project, i) => (
+          <AnimatedGridItem key={project.name} index={i}>
+            <ProjectCard project={project} />
+          </AnimatedGridItem>
         ))}
-      </div>
+      </AnimatedGrid>
     </div>
   );
 }

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -71,8 +71,8 @@ export default function ProjectsPage() {
 
       {/* Project grid */}
       <AnimatedGrid className="mt-12 grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-        {remaining.map((project, i) => (
-          <AnimatedGridItem key={project.name} index={i}>
+        {remaining.map((project) => (
+          <AnimatedGridItem key={project.name}>
             <ProjectCard project={project} />
           </AnimatedGridItem>
         ))}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+
+import { siteConfig } from "@/config/site";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${siteConfig.url}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+
+import { siteConfig } from "@/config/site";
+import { getAllSlugs } from "@/lib/blog";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const blogSlugs = getAllSlugs();
+
+  const blogRoutes = blogSlugs.map((slug) => ({
+    url: `${siteConfig.url}/blog/${slug}`,
+    lastModified: new Date(),
+  }));
+
+  const routes = ["", "/about", "/projects", "/blog"].map((route) => ({
+    url: `${siteConfig.url}${route}`,
+    lastModified: new Date(),
+  }));
+
+  return [...routes, ...blogRoutes];
+}

--- a/components/animatedGrid.tsx
+++ b/components/animatedGrid.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export function AnimatedGrid({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <motion.div
+      animate="visible"
+      className={className}
+      initial="hidden"
+      variants={{
+        hidden: {},
+        visible: { transition: { staggerChildren: 0.1 } },
+      }}
+      viewport={{ once: true }}
+      whileInView="visible"
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function AnimatedGridItem({
+  children,
+  index,
+}: {
+  children: React.ReactNode;
+  index: number;
+}) {
+  return (
+    <motion.div
+      custom={index}
+      variants={{
+        hidden: { opacity: 0, y: 20 },
+        visible: (i: number) => ({
+          opacity: 1,
+          y: 0,
+          transition: {
+            delay: i * 0.1,
+            duration: 0.4,
+            ease: [0.25, 0.46, 0.45, 0.94],
+          },
+        }),
+      }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/components/animatedGrid.tsx
+++ b/components/animatedGrid.tsx
@@ -11,7 +11,6 @@ export function AnimatedGrid({
 }) {
   return (
     <motion.div
-      animate="visible"
       className={className}
       initial="hidden"
       variants={{
@@ -26,27 +25,19 @@ export function AnimatedGrid({
   );
 }
 
-export function AnimatedGridItem({
-  children,
-  index,
-}: {
-  children: React.ReactNode;
-  index: number;
-}) {
+export function AnimatedGridItem({ children }: { children: React.ReactNode }) {
   return (
     <motion.div
-      custom={index}
       variants={{
         hidden: { opacity: 0, y: 20 },
-        visible: (i: number) => ({
+        visible: {
           opacity: 1,
           y: 0,
           transition: {
-            delay: i * 0.1,
             duration: 0.4,
             ease: [0.25, 0.46, 0.45, 0.94],
           },
-        }),
+        },
       }}
     >
       {children}

--- a/components/blogPostCard.tsx
+++ b/components/blogPostCard.tsx
@@ -1,36 +1,76 @@
+"use client";
+
+import type { PostMeta } from "@/lib/blog";
+
 import { Card, CardHeader, CardBody, CardFooter } from "@nextui-org/react";
+import { motion } from "framer-motion";
+import Image from "next/image";
 import Link from "next/link";
 
-export default function PostCard({
-  post,
-}: {
-  post: { slug: string; title: string; summary: string };
-}) {
+export default function PostCard({ post }: { post: PostMeta }) {
   return (
-    <div>
-      <Card
-        isHoverable
-        className="p-4 border border-zinc-100 dark:border-zinc-700/40 text-left dark:bg-zinc-800/10 bg-zinc-50/10"
-      >
-        <CardHeader>
+    <motion.div transition={{ duration: 0.2 }} whileHover={{ y: -2 }}>
+      <Card className="overflow-hidden border border-zinc-100 bg-zinc-50/10 text-left transition-shadow duration-300 hover:shadow-md dark:border-zinc-700/40 dark:bg-zinc-800/10">
+        {post.image && (
+          <CardHeader className="overflow-hidden rounded-t-lg p-0">
+            <Image
+              alt={post.title}
+              className="h-40 w-full object-cover"
+              height={160}
+              src={post.image}
+              width={400}
+            />
+          </CardHeader>
+        )}
+        <CardHeader className="flex-col items-start px-5 pb-0 pt-5">
           <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
             {post.title}
           </h3>
+          <div className="mt-1 flex items-center gap-2 text-xs text-zinc-400 dark:text-zinc-500">
+            <time dateTime={post.publishedAt}>
+              {new Date(post.publishedAt).toLocaleDateString("en-US", {
+                month: "short",
+                day: "numeric",
+                year: "numeric",
+              })}
+            </time>
+            {post.readingTime && (
+              <>
+                <span aria-hidden="true">&middot;</span>
+                <span>{post.readingTime} min read</span>
+              </>
+            )}
+          </div>
         </CardHeader>
-        <CardBody>
+        <CardBody className="px-5">
           <p className="text-sm text-zinc-600 dark:text-zinc-400">
             {post.summary}
           </p>
+          {post.tags && post.tags.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {post.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="rounded-full bg-zinc-100 px-2 py-0.5 text-[10px] font-medium text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
         </CardBody>
-        <CardFooter>
+        <CardFooter className="px-5 pb-5 pt-2">
           <Link
-            className="text-sm font-medium text-primary-500 dark:text-primary-400"
+            className="group flex items-center gap-1 text-sm font-medium text-primary-500 dark:text-primary-400"
             href={`/blog/${post.slug}`}
           >
-            Read more →
+            Read more
+            <span className="inline-block transition-transform duration-200 group-hover:translate-x-1">
+              &rarr;
+            </span>
           </Link>
         </CardFooter>
       </Card>
-    </div>
+    </motion.div>
   );
 }

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import Link from "next/link";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faGithub,
+  faInstagram,
+  faLinkedin,
+  faXTwitter,
+} from "@fortawesome/free-brands-svg-icons";
+import { Popover, PopoverTrigger, PopoverContent } from "@nextui-org/react";
+
+import { siteConfig } from "@/config/site";
+
+const socialLinks = [
+  { href: siteConfig.links.twitter, icon: faXTwitter, label: "X" },
+  {
+    href: siteConfig.links.instagram,
+    icon: faInstagram,
+    label: "Instagram",
+  },
+  { href: siteConfig.links.github, icon: faGithub, label: "GitHub" },
+  {
+    href: "https://www.linkedin.com/in/ryanmilton",
+    icon: faLinkedin,
+    label: "LinkedIn",
+  },
+];
+
+export function Footer() {
+  return (
+    <footer className="mt-24 w-full border-t border-zinc-200 px-6 pb-8 pt-10 dark:border-zinc-800">
+      <div className="mx-auto max-w-5xl">
+        <div className="grid grid-cols-1 gap-8 md:grid-cols-3">
+          {/* Navigation */}
+          <div>
+            <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+              Navigation
+            </h3>
+            <ul className="mt-3 space-y-2">
+              {siteConfig.navItems.map((item) => (
+                <li key={item.href}>
+                  <Link
+                    className="text-sm text-zinc-500 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
+                    href={item.href}
+                  >
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Social */}
+          <div>
+            <h3 className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+              Connect
+            </h3>
+            <div className="mt-3 flex gap-4">
+              {socialLinks.map((link) => (
+                <a
+                  key={link.label}
+                  className="text-zinc-400 transition-colors hover:text-zinc-900 dark:hover:text-zinc-100"
+                  href={link.href}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <FontAwesomeIcon className="h-5 w-5" icon={link.icon} />
+                  <span className="sr-only">{link.label}</span>
+                </a>
+              ))}
+            </div>
+          </div>
+
+          {/* Coffee Easter Egg */}
+          <div className="flex items-start md:justify-end">
+            <div className="flex items-center gap-1 text-sm text-zinc-500 dark:text-zinc-400">
+              <span>Powered by</span>
+              <Popover placement="top" showArrow={true}>
+                <PopoverTrigger>
+                  <span className="cursor-pointer text-amber-900 transition-colors hover:text-amber-700">
+                    Coffee
+                  </span>
+                </PopoverTrigger>
+                <PopoverContent>
+                  <div className="max-w-40 px-1 py-2">
+                    <div className="text-xs font-semibold">
+                      A delicious hot beverage.
+                    </div>
+                    <div className="text-xs">
+                      Hazlenut - add a splash of cream 🤌🏻
+                    </div>
+                  </div>
+                </PopoverContent>
+              </Popover>
+            </div>
+          </div>
+        </div>
+
+        {/* Copyright */}
+        <div className="mt-8 border-t border-zinc-100 pt-6 dark:border-zinc-800">
+          <p className="text-xs text-zinc-400">
+            &copy; {new Date().getFullYear()} Ryan Milton. All rights reserved.
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/components/mdx/blog-image.tsx
+++ b/components/mdx/blog-image.tsx
@@ -1,0 +1,42 @@
+import Image from "next/image";
+
+interface BlogImageProps {
+  src?: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+}
+
+export function BlogImage({ src, alt, width, height }: BlogImageProps) {
+  if (!src) return null;
+
+  const isExternal = src.startsWith("http");
+
+  return (
+    <figure className="my-8">
+      {isExternal ? (
+        // eslint-disable-next-line
+        <img
+          alt={alt || ""}
+          className="w-full rounded-lg"
+          loading="lazy"
+          src={src}
+        />
+      ) : (
+        <Image
+          alt={alt || ""}
+          className="rounded-lg"
+          height={height || 630}
+          sizes="(max-width: 768px) 100vw, 720px"
+          src={src}
+          width={width || 1200}
+        />
+      )}
+      {alt && (
+        <figcaption className="mt-2 text-center text-sm text-zinc-500 dark:text-zinc-400">
+          {alt}
+        </figcaption>
+      )}
+    </figure>
+  );
+}

--- a/components/mdx/callout.tsx
+++ b/components/mdx/callout.tsx
@@ -1,0 +1,26 @@
+interface CalloutProps {
+  children: React.ReactNode;
+  type?: "info" | "warning" | "tip" | "note";
+}
+
+const styles: Record<string, string> = {
+  info: "border-blue-500 bg-blue-50 dark:bg-blue-950/30 text-blue-900 dark:text-blue-200",
+  warning:
+    "border-amber-500 bg-amber-50 dark:bg-amber-950/30 text-amber-900 dark:text-amber-200",
+  tip: "border-green-500 bg-green-50 dark:bg-green-950/30 text-green-900 dark:text-green-200",
+  note: "border-zinc-400 bg-zinc-50 dark:bg-zinc-800/50 text-zinc-800 dark:text-zinc-200",
+};
+
+export function Callout({ children, type = "note" }: CalloutProps) {
+  return (
+    <aside
+      className={`my-6 rounded-lg border-l-4 p-4 not-prose ${styles[type]}`}
+      role="note"
+    >
+      <div className="mb-1 text-sm font-medium uppercase tracking-wide opacity-70">
+        {type}
+      </div>
+      <div className="text-sm">{children}</div>
+    </aside>
+  );
+}

--- a/components/mdx/code-block.tsx
+++ b/components/mdx/code-block.tsx
@@ -1,0 +1,24 @@
+interface CodeBlockProps extends React.HTMLAttributes<HTMLPreElement> {
+  children: React.ReactNode;
+  "data-language"?: string;
+}
+
+export function CodeBlock(props: CodeBlockProps) {
+  const { children, "data-language": language, ...rest } = props;
+
+  return (
+    <div className="group relative my-6">
+      {language && (
+        <span className="absolute right-3 top-2 z-10 font-mono text-xs text-zinc-400 dark:text-zinc-500">
+          {language}
+        </span>
+      )}
+      <pre
+        {...rest}
+        className="overflow-x-auto rounded-lg border border-zinc-200 bg-zinc-50 p-4 text-sm dark:border-zinc-700 dark:bg-zinc-900"
+      >
+        {children}
+      </pre>
+    </div>
+  );
+}

--- a/components/mdx/index.ts
+++ b/components/mdx/index.ts
@@ -1,0 +1,16 @@
+import type { MDXComponents } from "mdx/types";
+
+import { BlogImage } from "./blog-image";
+import { Callout } from "./callout";
+import { CodeBlock } from "./code-block";
+import { VideoEmbed } from "./video-embed";
+
+export const mdxComponents: MDXComponents = {
+  // @ts-expect-error -- BlogImage accepts narrower props than the generic img type
+  img: BlogImage,
+  // @ts-expect-error -- CodeBlock accepts narrower props than the generic pre type
+  pre: CodeBlock,
+  Callout,
+  BlogImage,
+  VideoEmbed,
+};

--- a/components/mdx/table-of-contents.tsx
+++ b/components/mdx/table-of-contents.tsx
@@ -1,0 +1,32 @@
+import { TocItem } from "@/lib/toc";
+
+interface TableOfContentsProps {
+  items: TocItem[];
+}
+
+export function TableOfContents({ items }: TableOfContentsProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <nav
+      aria-label="Table of contents"
+      className="mb-8 rounded-lg border border-zinc-200 p-4 dark:border-zinc-700"
+    >
+      <h2 className="mb-3 text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+        On this page
+      </h2>
+      <ul className="space-y-1.5 text-sm">
+        {items.map((item) => (
+          <li key={item.id} className={item.level === 3 ? "pl-4" : ""}>
+            <a
+              className="text-zinc-500 transition-colors hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200"
+              href={`#${item.id}`}
+            >
+              {item.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/components/mdx/video-embed.tsx
+++ b/components/mdx/video-embed.tsx
@@ -1,0 +1,62 @@
+interface VideoEmbedProps {
+  url: string;
+  title?: string;
+}
+
+function getVideoId(url: string): {
+  provider: "youtube" | "vimeo" | null;
+  id: string | null;
+} {
+  const ytMatch = url.match(
+    /(?:youtube\.com\/(?:watch\?v=|embed\/)|youtu\.be\/)([\w-]{11})/,
+  );
+
+  if (ytMatch) return { provider: "youtube", id: ytMatch[1] };
+
+  const vimeoMatch = url.match(
+    /(?:vimeo\.com\/|player\.vimeo\.com\/video\/)(\d+)/,
+  );
+
+  if (vimeoMatch) return { provider: "vimeo", id: vimeoMatch[1] };
+
+  return { provider: null, id: null };
+}
+
+function getEmbedUrl(provider: "youtube" | "vimeo", id: string): string {
+  if (provider === "youtube") {
+    return `https://www.youtube-nocookie.com/embed/${id}`;
+  }
+
+  return `https://player.vimeo.com/video/${id}`;
+}
+
+export function VideoEmbed({ url, title }: VideoEmbedProps) {
+  const { provider, id } = getVideoId(url);
+
+  if (!provider || !id) {
+    return (
+      <p className="text-red-500 dark:text-red-400">Invalid video URL: {url}</p>
+    );
+  }
+
+  const embedUrl = getEmbedUrl(provider, id);
+
+  return (
+    <figure className="my-8">
+      <div className="relative aspect-video overflow-hidden rounded-lg border border-zinc-200 dark:border-zinc-700">
+        <iframe
+          allowFullScreen
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          className="absolute inset-0 h-full w-full"
+          src={embedUrl}
+          title={title || "Embedded video"}
+        />
+      </div>
+      {title && (
+        <figcaption className="mt-2 text-center text-sm text-zinc-500 dark:text-zinc-400">
+          {title}
+        </figcaption>
+      )}
+    </figure>
+  );
+}

--- a/components/motion/fade-in.tsx
+++ b/components/motion/fade-in.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+
+interface FadeInProps {
+  children: React.ReactNode;
+  className?: string;
+  delay?: number;
+  direction?: "up" | "down" | "left" | "right" | "none";
+  duration?: number;
+}
+
+const directionOffset = {
+  up: { y: 20 },
+  down: { y: -20 },
+  left: { x: 20 },
+  right: { x: -20 },
+  none: {},
+};
+
+export function FadeIn({
+  children,
+  className,
+  delay = 0,
+  direction = "up",
+  duration = 0.5,
+}: FadeInProps) {
+  const shouldReduceMotion = useReducedMotion();
+
+  if (shouldReduceMotion) {
+    return <div className={className}>{children}</div>;
+  }
+
+  const offset = directionOffset[direction];
+
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, ...offset }}
+      transition={{ delay, duration, ease: [0.25, 0.46, 0.45, 0.94] }}
+      viewport={{ once: true, margin: "-100px" }}
+      whileInView={{ opacity: 1, x: 0, y: 0 }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/components/motion/index.ts
+++ b/components/motion/index.ts
@@ -1,0 +1,3 @@
+export { FadeIn } from "./fade-in";
+export { PageTransition } from "./page-transition";
+export { StaggerChildren } from "./stagger-children";

--- a/components/motion/page-transition.tsx
+++ b/components/motion/page-transition.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+import { usePathname } from "next/navigation";
+
+interface PageTransitionProps {
+  children: React.ReactNode;
+}
+
+export function PageTransition({ children }: PageTransitionProps) {
+  const pathname = usePathname();
+  const shouldReduceMotion = useReducedMotion();
+
+  if (shouldReduceMotion) {
+    return <>{children}</>;
+  }
+
+  return (
+    <motion.div
+      key={pathname}
+      animate={{ opacity: 1, y: 0 }}
+      initial={{ opacity: 0, y: 8 }}
+      transition={{ duration: 0.3, ease: "easeInOut" }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/components/motion/stagger-children.tsx
+++ b/components/motion/stagger-children.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+
+interface StaggerChildrenProps {
+  children: React.ReactNode;
+  className?: string;
+  staggerDelay?: number;
+}
+
+export function StaggerChildren({
+  children,
+  className,
+  staggerDelay = 0.1,
+}: StaggerChildrenProps) {
+  const shouldReduceMotion = useReducedMotion();
+
+  if (shouldReduceMotion) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return (
+    <motion.div
+      className={className}
+      initial="hidden"
+      variants={{
+        hidden: {},
+        visible: {
+          transition: { staggerChildren: staggerDelay },
+        },
+      }}
+      viewport={{ once: true, margin: "-100px" }}
+      whileInView="visible"
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -9,50 +9,59 @@ import {
   NavbarMenuItem,
   link as linkStyles,
 } from "@nextui-org/react";
+import { motion } from "framer-motion";
 import NextLink from "next/link";
+import { usePathname } from "next/navigation";
 import clsx from "clsx";
 import Image from "next/image";
-import { useEffect, useState } from "react";
 
 import { siteConfig } from "@/config/site";
 import { ThemeSwitch } from "@/components/theme-switch";
 import profilePic from "@/assets/FB_Profile.jpg";
 
 export const Navbar = () => {
-  const [active, setActive] = useState("/");
-
-  useEffect(() => {
-    setActive(window.location.pathname);
-  }, []);
+  const pathname = usePathname();
 
   return (
-    <NextUINavbar className="bg-transparent" maxWidth="lg" position="sticky">
+    <NextUINavbar
+      isBlurred
+      className="bg-zinc-50/70 dark:bg-zinc-950/70"
+      maxWidth="lg"
+      position="sticky"
+    >
       <NavbarBrand className="hidden md:flex">
-        <NextLink passHref href="/" onClick={() => setActive("/")}>
+        <NextLink passHref href="/">
           <Image
             alt="Profile Picture"
-            className="w-8 h-8 rounded-full"
+            className="h-8 w-8 rounded-full"
             src={profilePic}
           />
         </NextLink>
       </NavbarBrand>
       <NavbarContent justify="center">
-        <ul className="hidden md:flex gap-8 justify-start ml-2 bg-zinc-200 dark:bg-zinc-900 py-2 px-6 rounded-full">
+        <ul className="hidden md:flex gap-8 justify-start ml-2 bg-zinc-200/80 dark:bg-zinc-900/80 py-2 px-6 rounded-full backdrop-blur-sm">
           {siteConfig.navItems.map((item) => (
             <NavbarItem key={item.href}>
               <NextLink
                 className={clsx(
                   linkStyles({ color: "foreground" }),
-                  `${active === item.href ? "text-primary" : "text-foreground"}`,
+                  `${pathname === item.href ? "text-primary" : "text-foreground"}`,
                   "relative",
                 )}
                 color="foreground"
                 href={item.href}
-                onClick={() => setActive(item.href)}
               >
                 {item.label}
-                {active === item.href && (
-                  <span className="absolute inset-x-0 -bottom-px h-px bg-gradient-to-r from-primary-500/0 via-primary-500/40 to-primary-500/0 dark:from-primary-400/0 dark:via-primary-400/40 dark:to-primary-400/0" />
+                {pathname === item.href && (
+                  <motion.span
+                    className="absolute inset-x-0 -bottom-px h-px bg-gradient-to-r from-primary-500/0 via-primary-500/40 to-primary-500/0 dark:from-primary-400/0 dark:via-primary-400/40 dark:to-primary-400/0"
+                    layoutId="navbar-active"
+                    transition={{
+                      type: "spring",
+                      stiffness: 380,
+                      damping: 30,
+                    }}
+                  />
                 )}
               </NextLink>
             </NavbarItem>
@@ -74,23 +83,26 @@ export const Navbar = () => {
         <div className="mx-4 mt-2 flex flex-col gap-2">
           {siteConfig.navMenuItems.map((item, index) => (
             <NavbarMenuItem key={`${item}-${index}`}>
-              <NextLink
-                className={clsx(
-                  linkStyles({ color: "foreground" }),
-                  `${active === item.href ? "text-primary" : "text-foreground"}`,
-                  "relative text-2xl",
-                )}
-                color="foreground"
-                href={item.href}
-                onClick={() => {
-                  setActive(item.href);
-                }}
+              <motion.div
+                animate={{ opacity: 1, x: 0 }}
+                initial={{ opacity: 0, x: -20 }}
+                transition={{ delay: index * 0.05 }}
               >
-                {item.label}
-                {active === item.href && (
-                  <span className="absolute inset-x-0 -bottom-px h-px bg-gradient-to-r from-primary-500/0 via-primary-500/40 to-primary-500/0 dark:from-primary-400/0 dark:via-primary-400/40 dark:to-primary-400/0" />
-                )}
-              </NextLink>
+                <NextLink
+                  className={clsx(
+                    linkStyles({ color: "foreground" }),
+                    `${pathname === item.href ? "text-primary" : "text-foreground"}`,
+                    "relative text-2xl",
+                  )}
+                  color="foreground"
+                  href={item.href}
+                >
+                  {item.label}
+                  {pathname === item.href && (
+                    <span className="absolute inset-x-0 -bottom-px h-px bg-gradient-to-r from-primary-500/0 via-primary-500/40 to-primary-500/0 dark:from-primary-400/0 dark:via-primary-400/40 dark:to-primary-400/0" />
+                  )}
+                </NextLink>
+              </motion.div>
             </NavbarMenuItem>
           ))}
         </div>

--- a/components/projectCard.tsx
+++ b/components/projectCard.tsx
@@ -1,71 +1,88 @@
+"use client";
+
 import { Card, CardHeader, CardBody, CardFooter } from "@nextui-org/react";
+import { motion } from "framer-motion";
 import Link from "next/link";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faGithub } from "@fortawesome/free-brands-svg-icons";
 import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 
 import { Project } from "@/config/projects";
+import { accentClasses } from "@/config/colors";
 
 export default function ProjectCard({ project }: { project: Project }) {
+  const accent = project.accent || "blue";
+  const classes = accentClasses[accent];
+
   return (
-    <Card
-      isHoverable
-      className="p-4 border border-zinc-100 dark:border-zinc-700/40 dark:bg-zinc-800/10 bg-zinc-50/10 h-full"
+    <motion.div
+      className="h-full"
+      transition={{ duration: 0.25, ease: "easeOut" }}
+      whileHover={{ y: -4 }}
     >
-      <CardHeader className="flex-col items-start gap-1">
-        <div className="flex items-center justify-between w-full">
-          <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
-            {project.name}
-          </h3>
-          <span className="text-xs text-zinc-400 dark:text-zinc-500">
-            {project.year}
-          </span>
-        </div>
-      </CardHeader>
-      <CardBody>
-        <p className="text-sm text-zinc-600 dark:text-zinc-400">
-          {project.description}
-        </p>
-        <div className="mt-4 flex flex-wrap gap-2">
-          {project.techStack.map((tech) => (
+      <Card
+        className={`h-full overflow-hidden border border-zinc-100 bg-zinc-50/10 transition-shadow duration-300 hover:shadow-lg dark:border-zinc-700/40 dark:bg-zinc-800/10 ${classes.glow}`}
+      >
+        <div
+          className={`h-[3px] bg-gradient-to-r ${classes.border} opacity-80 transition-opacity group-hover:opacity-100`}
+        />
+        <CardHeader className="flex-col items-start gap-1 px-5 pt-5">
+          <div className="flex w-full items-center justify-between">
+            <h3 className="text-xl font-bold text-zinc-900 dark:text-zinc-100">
+              {project.name}
+            </h3>
             <span
-              key={tech}
-              className="rounded-full bg-zinc-100 px-3 py-1 text-xs font-medium text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
+              className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${classes.badge}`}
             >
-              {tech}
+              {project.year}
             </span>
-          ))}
-        </div>
-      </CardBody>
-      {(project.liveUrl || project.repoUrl) && (
-        <CardFooter className="gap-3">
-          {project.liveUrl && (
-            <Link
-              className="flex items-center gap-1.5 text-sm font-medium text-primary-500 dark:text-primary-400 hover:underline"
-              href={project.liveUrl}
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              <FontAwesomeIcon
-                className="h-3.5 w-3.5"
-                icon={faArrowUpRightFromSquare}
-              />
-              Live
-            </Link>
-          )}
-          {project.repoUrl && (
-            <Link
-              className="flex items-center gap-1.5 text-sm font-medium text-zinc-600 dark:text-zinc-400 hover:text-primary-500 dark:hover:text-primary-400"
-              href={project.repoUrl}
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              <FontAwesomeIcon className="h-4 w-4" icon={faGithub} />
-              Source
-            </Link>
-          )}
-        </CardFooter>
-      )}
-    </Card>
+          </div>
+        </CardHeader>
+        <CardBody className="px-5">
+          <p className="text-sm leading-relaxed text-zinc-600 dark:text-zinc-400">
+            {project.description}
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {project.techStack.map((tech) => (
+              <span
+                key={tech}
+                className={`rounded-full px-3 py-1 text-xs font-medium ${classes.badge}`}
+              >
+                {tech}
+              </span>
+            ))}
+          </div>
+        </CardBody>
+        {(project.liveUrl || project.repoUrl) && (
+          <CardFooter className="gap-3 px-5 pb-5">
+            {project.liveUrl && (
+              <Link
+                className="flex items-center gap-1.5 text-sm font-medium text-primary-500 transition-colors duration-200 hover:underline dark:text-primary-400"
+                href={project.liveUrl}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <FontAwesomeIcon
+                  className="h-3.5 w-3.5"
+                  icon={faArrowUpRightFromSquare}
+                />
+                Live
+              </Link>
+            )}
+            {project.repoUrl && (
+              <Link
+                className="flex items-center gap-1.5 text-sm font-medium text-zinc-600 transition-colors duration-200 hover:text-primary-500 dark:text-zinc-400 dark:hover:text-primary-400"
+                href={project.repoUrl}
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                <FontAwesomeIcon className="h-4 w-4" icon={faGithub} />
+                Source
+              </Link>
+            )}
+          </CardFooter>
+        )}
+      </Card>
+    </motion.div>
   );
 }

--- a/components/resume.tsx
+++ b/components/resume.tsx
@@ -4,7 +4,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Button } from "@nextui-org/react";
 import { Card, CardHeader, CardBody, CardFooter } from "@nextui-org/react";
 import Image, { ImageProps } from "next/image";
-import Link from "next/link";
 
 import Anduril from "@/assets/Anduril Logo.png";
 import Buddy from "@/assets/Buddy Tech Logo.jpg";
@@ -32,7 +31,6 @@ function RoleItem({ role }: { role: Role }) {
     <li className="flex gap-4">
       <div className="relative mt-1 flex h-10 w-10 flex-none items-center justify-center rounded-full shadow-md shadow-zinc-800/5 ring-1 ring-zinc-900/5 dark:border dark:border-zinc-700/50 dark:bg-zinc-800 dark:ring-0">
         <Image
-          unoptimized
           alt={role.company}
           className="rounded-full"
           height={40}
@@ -115,7 +113,7 @@ export default function Resume() {
       </CardBody>
       <CardFooter>
         <Button
-          as={Link}
+          as="a"
           className="group mt-3 w-full"
           color="default"
           download="Ryan_Milton_Resume.pdf"

--- a/config/colors.ts
+++ b/config/colors.ts
@@ -1,0 +1,49 @@
+export const accentGradients = {
+  violet: { from: "#FF1CF7", to: "#b249f8" },
+  yellow: { from: "#FF705B", to: "#FFB457" },
+  blue: { from: "#5EA2EF", to: "#0072F5" },
+  cyan: { from: "#00b7fa", to: "#01cfea" },
+  green: { from: "#6FEE8D", to: "#17c964" },
+  pink: { from: "#FF72E1", to: "#F54C7A" },
+} as const;
+
+export type AccentColor = keyof typeof accentGradients;
+
+export const accentClasses: Record<
+  AccentColor,
+  { border: string; badge: string; glow: string }
+> = {
+  violet: {
+    border: "from-[#FF1CF7] to-[#b249f8]",
+    badge:
+      "bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300",
+    glow: "hover:shadow-purple-500/10 dark:hover:shadow-purple-500/20",
+  },
+  yellow: {
+    border: "from-[#FF705B] to-[#FFB457]",
+    badge:
+      "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300",
+    glow: "hover:shadow-orange-500/10 dark:hover:shadow-orange-500/20",
+  },
+  blue: {
+    border: "from-[#5EA2EF] to-[#0072F5]",
+    badge: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+    glow: "hover:shadow-blue-500/10 dark:hover:shadow-blue-500/20",
+  },
+  cyan: {
+    border: "from-[#00b7fa] to-[#01cfea]",
+    badge: "bg-cyan-100 text-cyan-700 dark:bg-cyan-900/30 dark:text-cyan-300",
+    glow: "hover:shadow-cyan-500/10 dark:hover:shadow-cyan-500/20",
+  },
+  green: {
+    border: "from-[#6FEE8D] to-[#17c964]",
+    badge:
+      "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300",
+    glow: "hover:shadow-emerald-500/10 dark:hover:shadow-emerald-500/20",
+  },
+  pink: {
+    border: "from-[#FF72E1] to-[#F54C7A]",
+    badge: "bg-pink-100 text-pink-700 dark:bg-pink-900/30 dark:text-pink-300",
+    glow: "hover:shadow-pink-500/10 dark:hover:shadow-pink-500/20",
+  },
+};

--- a/config/fonts.ts
+++ b/config/fonts.ts
@@ -1,21 +1,13 @@
-// System font stacks — no network fetch required.
-// Replace with next/font/google imports (Ubuntu, Ubuntu_Mono) when deploying
-// to an environment with internet access (e.g. Vercel).
+import { Ubuntu, Ubuntu_Mono } from "next/font/google";
 
-export const fontSans = {
-  className: "",
+export const fontSans = Ubuntu({
+  subsets: ["latin"],
   variable: "--font-sans",
-  style: {
-    fontFamily:
-      "'Ubuntu', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif",
-  },
-};
+  weight: ["300", "400", "500", "700"],
+});
 
-export const fontMono = {
-  className: "",
+export const fontMono = Ubuntu_Mono({
+  subsets: ["latin"],
   variable: "--font-mono",
-  style: {
-    fontFamily:
-      "'Ubuntu Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace",
-  },
-};
+  weight: ["400", "700"],
+});

--- a/config/projects.ts
+++ b/config/projects.ts
@@ -1,3 +1,5 @@
+import type { AccentColor } from "./colors";
+
 export interface Project {
   name: string;
   description: string;
@@ -5,6 +7,8 @@ export interface Project {
   liveUrl?: string;
   repoUrl?: string;
   year: string;
+  accent?: AccentColor;
+  featured?: boolean;
 }
 
 export const projects: Project[] = [
@@ -14,6 +18,8 @@ export const projects: Project[] = [
       "A next-generation digital assistant powered by multi-modal large language models. Co-founded as CTO, building the future of AI-driven personal assistance.",
     techStack: ["TypeScript", "React", "Node.js", "LLMs", "AI/ML"],
     year: "2024",
+    accent: "violet",
+    featured: true,
   },
   {
     name: "OhKei Life",
@@ -22,6 +28,7 @@ export const projects: Project[] = [
     techStack: ["React", "Next.js", "Tailwind CSS"],
     liveUrl: "https://www.instagram.com/ryan_ohkeilife",
     year: "2024",
+    accent: "yellow",
   },
   {
     name: "Focus App",
@@ -29,6 +36,7 @@ export const projects: Project[] = [
       "A productivity application designed to help users maintain deep focus through flexible time blocks, ambient soundscapes, and distraction-free workflows.",
     techStack: ["React Native", "TypeScript", "Node.js"],
     year: "2024",
+    accent: "cyan",
   },
   {
     name: "Portfolio",
@@ -37,5 +45,6 @@ export const projects: Project[] = [
     techStack: ["Next.js", "TypeScript", "Tailwind CSS", "MDX"],
     repoUrl: "https://github.com/Ryan-Milton/Portfolio",
     year: "2024",
+    accent: "green",
   },
 ];

--- a/config/site.ts
+++ b/config/site.ts
@@ -3,6 +3,7 @@ export type SiteConfig = typeof siteConfig;
 export const siteConfig = {
   name: "Ryan Milton",
   description: "Software designer, creator, and kei car enthusiast.",
+  url: "https://ryguy.dev",
   navItems: [
     {
       label: "About",

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -34,7 +34,7 @@ export function getAllPosts(): PostMeta[] {
       summary: data.summary,
       publishedAt: data.publishedAt,
       tags: data.tags,
-      image: data.image || null,
+      image: data.image ?? undefined,
       readingTime: Math.ceil(readingTime(content).minutes),
     };
   });
@@ -59,7 +59,7 @@ export function getPostBySlug(slug: string): Post | null {
     summary: data.summary,
     publishedAt: data.publishedAt,
     tags: data.tags,
-    image: data.image || null,
+    image: data.image ?? undefined,
     content,
   };
 }

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 
 import matter from "gray-matter";
+import readingTime from "reading-time";
 
 const BLOG_DIR = path.join(process.cwd(), "content/blog");
 
@@ -11,6 +12,8 @@ export interface PostMeta {
   summary: string;
   publishedAt: string;
   tags?: string[];
+  image?: string;
+  readingTime?: number;
 }
 
 export interface Post extends PostMeta {
@@ -23,7 +26,7 @@ export function getAllPosts(): PostMeta[] {
   const posts: PostMeta[] = files.map((filename) => {
     const slug = filename.replace(/\.mdx$/, "");
     const raw = fs.readFileSync(path.join(BLOG_DIR, filename), "utf-8");
-    const { data } = matter(raw);
+    const { data, content } = matter(raw);
 
     return {
       slug,
@@ -31,6 +34,8 @@ export function getAllPosts(): PostMeta[] {
       summary: data.summary,
       publishedAt: data.publishedAt,
       tags: data.tags,
+      image: data.image || null,
+      readingTime: Math.ceil(readingTime(content).minutes),
     };
   });
 
@@ -54,8 +59,15 @@ export function getPostBySlug(slug: string): Post | null {
     summary: data.summary,
     publishedAt: data.publishedAt,
     tags: data.tags,
+    image: data.image || null,
     content,
   };
+}
+
+export function getReadingTime(content: string): number {
+  const result = readingTime(content);
+
+  return Math.ceil(result.minutes);
 }
 
 export function getAllSlugs(): string[] {

--- a/lib/mdx-options.ts
+++ b/lib/mdx-options.ts
@@ -1,0 +1,27 @@
+import remarkGfm from "remark-gfm";
+import rehypeSlug from "rehype-slug";
+import rehypeAutolinkHeadings from "rehype-autolink-headings";
+import rehypePrettyCode from "rehype-pretty-code";
+
+export const mdxOptions = {
+  remarkPlugins: [remarkGfm],
+  rehypePlugins: [
+    rehypeSlug,
+    [
+      rehypePrettyCode,
+      {
+        theme: { dark: "github-dark", light: "github-light" },
+        keepBackground: false,
+      },
+    ],
+    [
+      rehypeAutolinkHeadings,
+      {
+        behavior: "wrap",
+        properties: {
+          className: ["anchor"],
+        },
+      },
+    ],
+  ],
+};

--- a/lib/toc.ts
+++ b/lib/toc.ts
@@ -5,13 +5,20 @@ export interface TocItem {
 }
 
 export function extractToc(content: string): TocItem[] {
+  // Strip fenced code blocks to avoid matching headings inside them
+  const withoutCodeBlocks = content.replace(/```[\s\S]*?```/g, "");
+
   const headingRegex = /^(#{2,3})\s+(.+)$/gm;
   const toc: TocItem[] = [];
   let match;
 
-  while ((match = headingRegex.exec(content)) !== null) {
+  while ((match = headingRegex.exec(withoutCodeBlocks)) !== null) {
     const level = match[1].length;
-    const text = match[2].trim();
+    const text = match[2]
+      .trim()
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // strip [text](url) → text
+      .replace(/`([^`]+)`/g, "$1"); // strip backticks
+
     const id = text
       .toLowerCase()
       .replace(/[^\w\s-]/g, "")

--- a/lib/toc.ts
+++ b/lib/toc.ts
@@ -1,0 +1,24 @@
+export interface TocItem {
+  id: string;
+  text: string;
+  level: number;
+}
+
+export function extractToc(content: string): TocItem[] {
+  const headingRegex = /^(#{2,3})\s+(.+)$/gm;
+  const toc: TocItem[] = [];
+  let match;
+
+  while ((match = headingRegex.exec(content)) !== null) {
+    const level = match[1].length;
+    const text = match[2].trim();
+    const id = text
+      .toLowerCase()
+      .replace(/[^\w\s-]/g, "")
+      .replace(/\s+/g, "-");
+
+    toc.push({ id, text, level });
+  }
+
+  return toc;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,10 @@
 const withMDX = require("@next/mdx")();
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // Configure `pageExtensions` to include MDX files
   pageExtensions: ["js", "jsx", "mdx", "ts", "tsx"],
-  // Optionally, add any other Next.js config below
+  images: {
+    formats: ["image/avif", "image/webp"],
+  },
 };
 
 module.exports = withMDX(nextConfig);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,12 @@
 		"next-themes": "^0.4.4",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
+		"reading-time": "^1.5.0",
+		"rehype-autolink-headings": "^7.1.0",
+		"rehype-pretty-code": "^0.14.3",
+		"rehype-slug": "^6.0.0",
+		"remark-gfm": "^4.0.1",
+		"shiki": "^4.0.2",
 		"tailwind-variants": "^0.3.0"
 	},
 	"devDependencies": {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,3 +1,90 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Background atmosphere */
+.bg-atmosphere {
+  position: relative;
+}
+.bg-atmosphere::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  opacity: 0.03;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  pointer-events: none;
+}
+.bg-atmosphere::after {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 800px;
+  height: 600px;
+  z-index: -1;
+  pointer-events: none;
+  border-radius: 50%;
+  filter: blur(100px);
+  background: radial-gradient(
+    ellipse,
+    rgba(139, 92, 246, 0.04),
+    transparent 70%
+  );
+  animation: glow-pulse 8s ease-in-out infinite;
+}
+.dark .bg-atmosphere::after {
+  background: radial-gradient(
+    ellipse,
+    rgba(139, 92, 246, 0.08),
+    transparent 70%
+  );
+}
+
+/* rehype-pretty-code: dual theme support */
+[data-theme="light"] {
+  display: block;
+}
+[data-theme="dark"] {
+  display: none;
+}
+.dark [data-theme="light"] {
+  display: none;
+}
+.dark [data-theme="dark"] {
+  display: block;
+}
+
+/* rehype-pretty-code: line highlighting */
+[data-highlighted-line] {
+  background-color: rgba(200, 200, 255, 0.1);
+  border-left: 2px solid rgb(99, 102, 241);
+  padding-left: calc(1rem - 2px);
+}
+
+/* rehype-pretty-code: word highlighting */
+[data-highlighted-chars] {
+  background-color: rgba(200, 200, 255, 0.15);
+  border-radius: 0.25rem;
+  padding: 0.125rem 0.25rem;
+}
+
+/* Heading anchor links */
+.anchor {
+  text-decoration: none !important;
+  position: relative;
+}
+.anchor:hover::before {
+  content: "#";
+  position: absolute;
+  left: -1.5em;
+  color: rgb(161, 161, 170);
+  font-weight: 400;
+}
+
+/* Smooth scroll for anchor navigation */
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 5rem;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,20 +1,131 @@
-import {nextui} from '@nextui-org/theme'
+import { nextui } from "@nextui-org/theme";
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    './components/**/*.{js,ts,jsx,tsx,mdx}',
-    './app/**/*.{js,ts,jsx,tsx,mdx}',
-    './node_modules/@nextui-org/theme/dist/**/*.{js,ts,jsx,tsx}'
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./node_modules/@nextui-org/theme/dist/**/*.{js,ts,jsx,tsx}",
   ],
   theme: {
     extend: {
       fontFamily: {
         sans: ["var(--font-sans)"],
-        mono: ["var(--font-geist-mono)"],
+        mono: ["var(--font-mono)"],
       },
+      keyframes: {
+        "glow-pulse": {
+          "0%, 100%": { opacity: "0.04" },
+          "50%": { opacity: "0.08" },
+        },
+      },
+      animation: {
+        "glow-pulse": "glow-pulse 8s ease-in-out infinite",
+      },
+      typography: ({ theme }) => ({
+        DEFAULT: {
+          css: {
+            "--tw-prose-body": theme("colors.zinc.700"),
+            "--tw-prose-headings": theme("colors.zinc.900"),
+            "--tw-prose-links": theme("colors.zinc.900"),
+            "--tw-prose-bold": theme("colors.zinc.900"),
+            "--tw-prose-code": theme("colors.zinc.900"),
+            "--tw-prose-pre-bg": theme("colors.zinc.50"),
+            "--tw-prose-pre-code": theme("colors.zinc.800"),
+            "--tw-prose-th-borders": theme("colors.zinc.200"),
+            "--tw-prose-td-borders": theme("colors.zinc.100"),
+            h2: {
+              marginTop: "2em",
+              marginBottom: "0.75em",
+            },
+            h3: {
+              marginTop: "1.6em",
+              marginBottom: "0.6em",
+            },
+            a: {
+              textDecoration: "underline",
+              textUnderlineOffset: "3px",
+              textDecorationColor: theme("colors.zinc.300"),
+              "&:hover": {
+                textDecorationColor: theme("colors.zinc.500"),
+              },
+            },
+            "code::before": { content: '""' },
+            "code::after": { content: '""' },
+            code: {
+              fontWeight: "400",
+              backgroundColor: theme("colors.zinc.100"),
+              borderRadius: theme("borderRadius.md"),
+              padding: "0.2em 0.4em",
+              fontSize: "0.875em",
+            },
+            "ul > li::marker": {
+              color: theme("colors.zinc.400"),
+            },
+            "ol > li::marker": {
+              color: theme("colors.zinc.400"),
+            },
+            hr: {
+              borderColor: theme("colors.zinc.200"),
+              marginTop: "2.5em",
+              marginBottom: "2.5em",
+            },
+            blockquote: {
+              borderLeftColor: theme("colors.zinc.300"),
+              fontStyle: "normal",
+            },
+            table: {
+              fontSize: "0.875em",
+            },
+            thead: {
+              borderBottomColor: theme("colors.zinc.200"),
+            },
+            "thead th": {
+              fontWeight: "600",
+              padding: "0.75em 1em",
+            },
+            "tbody td": {
+              padding: "0.75em 1em",
+            },
+          },
+        },
+        invert: {
+          css: {
+            "--tw-prose-body": theme("colors.zinc.300"),
+            "--tw-prose-headings": theme("colors.zinc.100"),
+            "--tw-prose-links": theme("colors.zinc.100"),
+            "--tw-prose-bold": theme("colors.zinc.100"),
+            "--tw-prose-code": theme("colors.zinc.100"),
+            "--tw-prose-pre-bg": theme("colors.zinc.900"),
+            "--tw-prose-pre-code": theme("colors.zinc.200"),
+            "--tw-prose-th-borders": theme("colors.zinc.700"),
+            "--tw-prose-td-borders": theme("colors.zinc.800"),
+            a: {
+              textDecorationColor: theme("colors.zinc.600"),
+              "&:hover": {
+                textDecorationColor: theme("colors.zinc.400"),
+              },
+            },
+            code: {
+              backgroundColor: theme("colors.zinc.800"),
+            },
+            hr: {
+              borderColor: theme("colors.zinc.700"),
+            },
+            blockquote: {
+              borderLeftColor: theme("colors.zinc.600"),
+            },
+            "ul > li::marker": {
+              color: theme("colors.zinc.500"),
+            },
+            "ol > li::marker": {
+              color: theme("colors.zinc.500"),
+            },
+          },
+        },
+      }),
     },
   },
   darkMode: "class",
-  plugins: [require('@tailwindcss/typography'), nextui()],
-}
+  plugins: [require("@tailwindcss/typography"), nextui()],
+};


### PR DESCRIPTION
## Summary

Comprehensive portfolio overhaul: adds Framer Motion animations throughout, rich MDX blog system with syntax highlighting and custom components, fixes resume download, improves SEO infrastructure, and elevates the visual design with gradient accents, atmospheric backgrounds, and redesigned cards/footer.

---

## 🧑‍💼 Product Perspective

### What changed
The portfolio has been transformed from a static, text-heavy site into an animated, visually distinctive showcase. Visitors now see smooth entrance animations as they scroll, a redesigned hero section with gradient text, color-coded project cards, richer blog post cards with reading time and tags, a proper footer with navigation, and a polished navbar with backdrop blur. The blog system now supports syntax-highlighted code blocks, video embeds, callout boxes, and a table of contents. The resume download button actually works now.

### Why it matters
A software designer's portfolio should demonstrate design craft. The previous version was functional but forgettable — no animations, no visual personality, and several broken or incomplete features (empty resume PDF, unstyled error page, unused Framer Motion dependency). This update makes the site feel polished, memorable, and representative of the builder behind it.

### Acceptance criteria
- [ ] Homepage hero animates in with staggered fade-up on load
- [ ] "kei car enthusiast" displays in violet gradient text
- [ ] Navbar active indicator slides smoothly between items when navigating
- [ ] Project cards show colored gradient top-border and accent-tinted tech badges
- [ ] EVA renders as a featured project card above the grid on /projects
- [ ] Blog cards show date, reading time, and tags
- [ ] Blog posts render with syntax highlighting, linkable headings, and table of contents
- [ ] `<VideoEmbed>`, `<Callout>`, and `<BlogImage>` components work in MDX posts
- [ ] Resume download triggers browser save dialog on both homepage and about page
- [ ] Footer shows navigation, social icons, and coffee easter egg
- [ ] Error page displays styled layout with "Try again" and "Go home" buttons
- [ ] Dark mode works correctly across all pages
- [ ] `robots.txt` and `sitemap.xml` are generated
- [ ] Site builds with zero errors and passes lint

### Screenshots / recordings
Run `npm run dev` and navigate to `http://localhost:3000` to see all visual changes. Key pages to check: homepage, /projects, /blog, /about, and toggle dark/light mode.

---

## 🔧 Tech Lead Perspective

### What was changed and why

**Animation system** (`components/motion/`): Created 3 reusable `"use client"` wrapper components (`FadeIn`, `StaggerChildren`, `PageTransition`) around Framer Motion. This preserves the Server Component architecture — pages stay as server components and import thin client wrappers for animation only. `FadeIn` uses `whileInView` for scroll-triggered reveals and respects `prefers-reduced-motion` via Framer Motion's `useReducedMotion()`.

**Blog pipeline** (`lib/mdx-options.ts`, `components/mdx/`): Added remark-gfm (tables, strikethrough), rehype-pretty-code with Shiki (dual-theme syntax highlighting), rehype-slug + rehype-autolink-headings (linkable headings). Custom MDX components: `BlogImage` (figure/figcaption with Next.js Image), `VideoEmbed` (YouTube/Vimeo iframe parser), `Callout` (typed admonition boxes), `CodeBlock` (language label wrapper), `TableOfContents` (heading extraction from raw MDX).

**Visual design** (`styles/globals.css`, `tailwind.config.js`): Added background atmosphere (SVG noise texture + radial gradient glow with 8s pulse), customized @tailwindcss/typography with refined prose styles for both light and dark modes, added CSS for rehype-pretty-code dual themes and heading anchor hover indicators.

**Card redesigns** (`components/projectCard.tsx`, `components/blogPostCard.tsx`): Both converted to `"use client"` for Framer Motion hover animations. Project cards now have gradient top-borders and accent-tinted badges via a color system (`config/colors.ts`) that maps accent keys to Tailwind class fragments. Blog cards now display date, reading time, tags, and a sliding arrow on "Read more".

**Resume fix** (`components/resume.tsx`, `app/about/page.tsx`): Changed download button from `as={Link}` to `as="a"` so the HTML `download` attribute works. Added download link to About page's social links sidebar.

**SEO** (`app/robots.ts`, `app/sitemap.ts`, `app/layout.tsx`, `config/site.ts`): Added dynamic robots.txt/sitemap generation, Open Graph + Twitter card metadata, and `metadataBase` for absolute URL generation.

**Performance** (`config/fonts.ts`, `components/navbar.tsx`, `next.config.js`): Switched from system font fallback to `next/font/google` (Ubuntu), fixed navbar hydration mismatch (replaced `useEffect` + `window.location` with `usePathname()`), enabled AVIF/WebP image formats, added FontAwesome FOUC fix.

### Architecture & design decisions

The core architectural decision is the **Server Component + Client Wrapper** pattern. Pages remain server components for SEO, static generation, and filesystem access (`getAllPosts()` uses `fs`). Animation is achieved by importing `"use client"` wrapper components (`FadeIn`, `StaggerChildren`, `AnimatedGrid`) that accept `children` as a prop. This avoids converting entire page trees to client components.

The **accent color system** (`config/colors.ts`) maps semantic color names to concrete Tailwind class fragments (border gradients, badge backgrounds, hover glow shadows). This decouples the color palette from individual components — adding a new project with a color is a one-line config change.

**Blog MDX pipeline** uses `next-mdx-remote/rsc` with centralized plugin config in `lib/mdx-options.ts`. Plugins run server-side at build time (zero client JS for syntax highlighting). Custom components are assembled in `components/mdx/index.ts` and passed to `MDXRemote` as a single object.

### Alternatives considered

- **Page-level `"use client"` for animations**: Rejected because it would break `generateStaticParams`, `generateMetadata`, and filesystem blog reading. Wrapper components keep the boundary clean.
- **Click-to-load video thumbnails**: Considered for VideoEmbed but adds client component complexity for minimal gain (most posts will have 0-1 videos). Direct iframe is simpler.
- **AnimatePresence for page transitions**: Next.js App Router doesn't support `mode="wait"` with server components. Used `key={pathname}` on `motion.div` instead — replays entrance animation without exit coordination.
- **rehype-highlight instead of rehype-pretty-code**: Rejected because it requires client-side CSS loading. Shiki/rehype-pretty-code runs entirely server-side with VS Code-quality themes.

### Edge cases & error handling

- **Reduced motion**: All animation components check `useReducedMotion()` and render static `<div>` when the OS preference is set.
- **External images in blog**: `BlogImage` detects external URLs and falls back to `<img>` with `loading="lazy"` to avoid needing `remotePatterns` config for arbitrary domains.
- **Invalid video URLs**: `VideoEmbed` shows a red error message instead of a broken iframe when it can't parse a YouTube/Vimeo ID.
- **Missing blog image field**: Hero image in blog posts is optional — renders nothing when `post.image` is undefined.
- **Empty resume PDF**: The download infrastructure works, but `public/resume.pdf` is still 0 bytes. User needs to supply the actual file.

### Performance considerations

- Framer Motion was already in the bundle (NextUI dependency). The new animation components add minimal code — `motion.div` with `opacity` + `transform` only (GPU-composited).
- `viewport={{ once: true }}` ensures scroll animations play once, not on every scroll cycle.
- rehype-pretty-code/Shiki runs at build time only — zero client JS for syntax highlighting.
- `next/font/google` self-hosts Ubuntu fonts at build time, eliminating runtime Google Fonts requests.
- Background atmosphere uses CSS-only effects (no JavaScript) — the noise is an inline SVG data URI, the glow is a CSS radial gradient with CSS animation.

### Testing

- **No test framework configured** — the project has no unit or e2e tests.
- **Build verification**: `npm run build` passes with zero errors, all 13 static pages generated.
- **Lint verification**: `npm run lint` passes clean.
- **Manual testing**: All pages verified via dev server — homepage animations, project/blog card interactions, dark/light mode, mobile nav, resume download, blog post rendering.

### Rollout & risk

- **Blast radius**: This is a personal portfolio with no production traffic dependency. Full deploy with no feature flags is appropriate.
- **Rollback**: Revert the PR merge on main.
- **Known follow-ups**: User needs to replace `public/resume.pdf` with actual PDF. Blog posts could be enriched with the new MDX components (Callout, VideoEmbed, BlogImage) — currently none use them. The 2.4MB unused `assets/image-3.jpg` could be removed.

---

## Test plan

1. Run `npm run dev` and open `http://localhost:3000`
2. Verify homepage: hero text animates in, "kei car enthusiast" is violet gradient, social icons stagger in, scroll down to see featured posts and resume card fade in
3. Navigate to /projects: EVA featured card at top with violet accent, remaining cards stagger in with colored borders, hover cards to see lift + shadow
4. Navigate to /blog: cards stagger in showing date, reading time, and tags. Hover to see lift and sliding arrow
5. Click a blog post: verify table of contents, heading anchors (hover to see `#`), reading time, prose styling
6. Navigate to /about: profile image fades from right, bio paragraphs stagger, social links stagger, "Download Resume" link present
7. Click "Download Resume" on homepage and about page — browser should trigger save dialog
8. Toggle dark/light mode on every page — verify all gradients, atmosphere, and accents render correctly
9. Check mobile responsive: resize to mobile width, verify hamburger menu animates, cards stack correctly
10. Run `npm run build` — should complete with zero errors

---

## Related
- Follow-up: User needs to add actual resume PDF to `public/resume.pdf`
- Follow-up: Enrich existing blog posts with new MDX components (Callout, VideoEmbed, code blocks)
- Follow-up: Remove unused assets (`assets/image-3.jpg`, `assets/Anduril Lettered.png`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)